### PR TITLE
fix an error.

### DIFF
--- a/src/ctc_crf/gpu_den/fst_read.cc
+++ b/src/ctc_crf/gpu_den/fst_read.cc
@@ -22,7 +22,7 @@ void ReadFst(const char * fst_name,
     // assume that they are proper initialized
     StdVectorFst *fst = StdVectorFst::Read(fst_name);
     num_states = fst->NumStates(); 
-    int DEN_NUM_STATES = num_states;
+    DEN_NUM_STATES = num_states;
 
     num_arcs = 0;
     for (StateIterator<StdVectorFst> siter(*fst); !siter.Done(); siter.Next()) {


### PR DESCRIPTION
The extra `int` hides the global variable.

`DEN_NUM_STATES` and `DEN_NUM_ARCS` can be removed from the code
since they are used only for debugging purposes.